### PR TITLE
Dynamic URL rewriting

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -30,13 +30,12 @@ const rewriteUrls = function (html) {
         let fileContent;
 
         try {
-            fileContent = fs.readFileSync(oldPathName, 'utf8');
+            fileContent = markdown.toHTML(fs.readFileSync(oldPathName, 'utf8'));
         } catch (e) {
             fileContent = templates.error;
         }
 
-        const content = markdown.toHTML(fileContent);
-        const page = EJS.render(templates.page, { content });
+        const page = EJS.render(templates.page, { content: fileContent });
 
         fs.writeFileSync(newPathName, page, 'utf8');
         console.log(oldUrl, newUrl)

--- a/index.ts
+++ b/index.ts
@@ -1,21 +1,56 @@
 import * as fs from 'fs';
-
+import * as cheerio from 'cheerio';
 import * as EJS from 'ejs';
 import { markdown } from 'markdown';
 
 const catalog = require('./catalog.json');
 
 const templates = {
+    error: fs.readFileSync('./templates/error.ejs', 'utf8'),
     welcome: fs.readFileSync('./templates/welcome.ejs', 'utf8'),
     page: fs.readFileSync('./templates/page.ejs', 'utf8'),
     heuristic: fs.readFileSync('./templates/heuristic.ejs', 'utf8'),
     term: fs.readFileSync('./templates/term.ejs', 'utf8')
 };
 
+const rewriteUrls = function (html) {
+    const $ = cheerio.load(html);
+    const anchorsToRewrite = $('a[href]:not(.letter)')
+        .toArray()
+        .filter(el => !!~el.attribs.href.indexOf('.md'));
+
+    anchorsToRewrite.forEach(el => {
+        const oldUrl = el.attribs.href;
+        const fileName = oldUrl.split('/').pop().split('.')[0]; //Various issues with this (what if there are dots or slashes in filename?)
+        const oldPathName = `./terms/${fileName}.md`;
+
+        const newUrl = `dynamic_${fileName}.html`;
+        const newPathName = `./dist/dynamic_${fileName}.html`;
+
+        let fileContent;
+
+        try {
+            fileContent = fs.readFileSync(oldPathName, 'utf8');
+        } catch (e) {
+            fileContent = templates.error;
+        }
+
+        const content = markdown.toHTML(fileContent);
+        const page = EJS.render(templates.page, { content });
+
+        fs.writeFileSync(newPathName, page, 'utf8');
+        console.log(oldUrl, newUrl)
+        html = html.replace(new RegExp(oldUrl, 'g'), newUrl);
+    });
+    return html;
+}
+
 catalog.heuristics.map(h => {
     h.body = markdown.toHTML(fs.readFileSync(h.filename, 'utf8'));
 
-    const content = EJS.render(templates.heuristic, h);
+    let content = EJS.render(templates.heuristic, h);
+    content = rewriteUrls(content);
+
     const page = EJS.render(templates.page, { content });
     fs.writeFileSync(`./dist/${h.title}.html`, page, 'utf8');
 });
@@ -24,12 +59,18 @@ Object.keys(catalog.terms)
     .forEach(key => {
         const term = catalog.terms[key];
         term.body = markdown.toHTML(fs.readFileSync(term.filename, 'utf8'));
-        const content = EJS.render(templates.term, term);
+
+        let content = EJS.render(templates.term, term);
+        content = rewriteUrls(content);
+
         const page = EJS.render(templates.page, { content });
         fs.writeFileSync(`./dist/term_${key}.html`, page, 'utf8');
     });
 
 const welcomeBody = markdown.toHTML(fs.readFileSync('./terms/welcome.md', 'utf8'));
-const welcomeContent = EJS.render(templates.welcome, { content: welcomeBody, ...catalog });
+
+let welcomeContent = EJS.render(templates.welcome, { content: welcomeBody, ...catalog });
+welcomeContent = rewriteUrls(welcomeContent);
+
 const welcomePage = EJS.render(templates.page, { content: welcomeContent });
 fs.writeFileSync(`./dist/index.html`, welcomePage, 'utf8');

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
   },
   "homepage": "https://github.com/julianharty/testing-heuristics#readme",
   "dependencies": {
+    "@types/cheerio": "^0.22.1",
     "@types/core-js": "^0.9.41",
     "@types/ejs": "^2.3.33",
     "@types/node": "^7.0.16",
+    "cheerio": "^0.22.0",
     "core-js": "^2.4.1",
     "ejs": "^2.5.6",
     "less": "^2.7.2",

--- a/templates/error.ejs
+++ b/templates/error.ejs
@@ -1,0 +1,8 @@
+<h2>Uh oh, we couldn't find that page! (404)</h2>
+
+<button onclick='goBack()'>
+Click here to go back
+</button>
+
+
+<!-- TODO: Spruce this up -->


### PR DESCRIPTION
It's pretty difficult to detect the correct term-page, so instead we generate dynamic pages (not great, but better than nothing). When the file being linked to is missing, we show a sparse looking error page:

![image](https://cloud.githubusercontent.com/assets/5173131/25836694/c3fc560a-3480-11e7-887d-1f18eacef08f.png)

![image](https://cloud.githubusercontent.com/assets/5173131/25836700/cbe5612c-3480-11e7-9eba-6f8a683bbec4.png)

I think it's worth looking at this properly at some point to figure out if all links can be provided via the catalog.json file, or just linking to an html page that we know will exist (does work).